### PR TITLE
feat: set home page as default landing page.

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -17,9 +17,9 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     if (error.response?.status === 401) {
-      // Token expired, redirect to login
+      // Token expired, remove from storage but don't redirect automatically
       localStorage.removeItem('jwt');
-      window.location.href = '/login';
+      // window.location.href = '/login';
     }
     return Promise.reject(error);
   }

--- a/src/api/baseQueryWithAuth.ts
+++ b/src/api/baseQueryWithAuth.ts
@@ -15,8 +15,8 @@ export const baseQueryWithReauth: typeof baseQueryWithAuth = async (args, api, e
   const result = await baseQueryWithAuth(args, api, extraOptions);
   if (result.error && result.error.status === 401) {
     localStorage.removeItem('jwt');
-    // Optionally, redirect to login:
-    window.location.href = '/login';
+    // Don't automatically redirect to login - let components handle authentication as needed
+    // window.location.href = '/login';
   }
   return result;
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -180,10 +180,12 @@ const Header: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [accountMenuAnchor, setAccountMenuAnchor] = useState<null | HTMLElement>(null);
   const colorMode = useContext(ColorModeContext);
-  const { data: cartData } = useGetCartQuery(undefined, { skip: !localStorage.getItem('jwt') });
+  const { role } = useUserRole();
+  const isAuthenticated = !!localStorage.getItem('jwt');
+  const isAdmin = isAuthenticated && role === 'admin';
+  const { data: cartData } = useGetCartQuery(undefined, { skip: !isAuthenticated });
   const cartCount = cartData?.item_count || 0;
   const [logout] = useLogoutMutation();
-  const { role } = useUserRole();
 
   const handleFarmStoreClick = () => {
     // If clicking the main "Farm Store" button, navigate to all products
@@ -215,7 +217,10 @@ const Header: React.FC = () => {
     if (token) {
       setAccountMenuAnchor(event.currentTarget);
     } else {
-      navigate('/login');
+      // Show login prompt instead of redirecting
+      setAuthError('Please log in to access your account.');
+      // Optionally, you could show a login modal here instead
+      // navigate('/login');
     }
   };
 
@@ -233,7 +238,7 @@ const Header: React.FC = () => {
       await logout().unwrap();
       localStorage.removeItem('jwt');
       handleAccountMenuClose();
-      navigate('/login');
+      navigate('/');
     } catch (err) {
       setAuthError('Failed to logout.');
     }
@@ -915,7 +920,7 @@ const Header: React.FC = () => {
             </Box>
             
             {/* Admin-specific mobile menu items */}
-            {role === 'admin' && (
+            {isAdmin && (
               <>
                 <Divider sx={{ my: 2, mx: 2 }} />
                 <Typography
@@ -1159,7 +1164,7 @@ const Header: React.FC = () => {
           </MenuItem>
           
           {/* Admin-specific menu items */}
-          {role === 'admin' && (
+          {isAdmin && (
             <>
               <Divider sx={{ my: 1 }} />
               <MenuItem 

--- a/src/features/products/Form.tsx
+++ b/src/features/products/Form.tsx
@@ -113,10 +113,10 @@ export function ProductForm({ productId }: ProductFormProps) {
         formData.append('image', selectedImage);
       }
 
-      if (productId) {
+    if (productId) {
         await updateProduct({ id: productId, data: formData }).unwrap();
         enqueueSnackbar('Product updated successfully!', { variant: 'success' });
-      } else {
+    } else {
         await createProduct(formData).unwrap();
         enqueueSnackbar('Product created successfully!', { variant: 'success' });
       }
@@ -396,7 +396,7 @@ export function ProductForm({ productId }: ProductFormProps) {
           </Box>
         </Paper>
       </Container>
-    </Box>
+      </Box>
   );
 }
 
@@ -416,4 +416,4 @@ const Container: React.FC<{ children: React.ReactNode; maxWidth?: 'xs' | 'sm' | 
   >
     {children}
   </Box>
-);
+  );

--- a/src/features/products/api.ts
+++ b/src/features/products/api.ts
@@ -1,5 +1,11 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { baseQueryWithReauth } from '../../api/baseQueryWithAuth';
+import { fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+// Base query for public endpoints (no authentication required)
+const baseQueryPublic = fetchBaseQuery({
+  baseUrl: import.meta.env.VITE_API_URL || 'http://localhost:8000/api',
+});
 
 export type Category = { id: number; name: string; description?: string };
 
@@ -7,6 +13,7 @@ export const productsApi = createApi({
   reducerPath: 'productsApi',
   baseQuery: baseQueryWithReauth,
   endpoints: (builder) => ({
+    // Public endpoints (no authentication required)
     getProducts: builder.query<any[], void>({
       query: () => '/products/products/',
       transformResponse: (response: { results: any[] }) => response.results || [],
@@ -22,7 +29,15 @@ export const productsApi = createApi({
     getProduct: builder.query<any, number>({
       query: (id) => `/products/products/${id}/`,
     }),
-    // Admin only:
+    getCategories: builder.query<Category[], void>({
+      query: () => '/products/categories/',
+      transformResponse: (response: { results: Category[] }) => response.results || [],
+    }),
+    getCategory: builder.query<Category, number>({
+      query: (id) => `/products/categories/${id}/`,
+    }),
+    
+    // Admin endpoints (authentication required)
     createProduct: builder.mutation<any, Partial<any>>({
       query: (body) => ({
         url: '/products/products/',
@@ -42,15 +57,6 @@ export const productsApi = createApi({
         url: `/products/products/${id}/`,
         method: 'DELETE',
       }),
-    }),
-    // --- Updated to return full category objects ---
-    getCategories: builder.query<Category[], void>({
-      query: () => '/products/categories/',
-      transformResponse: (response: { results: Category[] }) => response.results || [],
-    }),
-    // Category endpoints
-    getCategory: builder.query<Category, number>({
-      query: (id) => `/products/categories/${id}/`,
     }),
     createCategory: builder.mutation<Category, { name: string; description?: string }>({
       query: (body) => ({

--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -1,6 +1,9 @@
 import { useGetProfileQuery } from '../features/auth/userApi';
 
 export function useUserRole() {
-  const { data, isLoading } = useGetProfileQuery();
-  return { role: data?.role, isLoading };
+  const hasToken = !!localStorage.getItem('jwt');
+  const { data, isLoading } = useGetProfileQuery(undefined, { 
+    skip: !hasToken 
+  });
+  return { role: data?.role, isLoading: hasToken ? isLoading : false };
 }


### PR DESCRIPTION
- Remove automatic redirects to login on 401 errors in API calls
- Update header to show login prompt instead of redirecting when clicking account menu
- Change logout behavior to redirect to home page instead of login page
- Keep appropriate authentication redirects for protected features (cart, profile, orders)
- Improve user experience by allowing browsing without forced authentication

This allows users to explore products and public pages before being required to login.